### PR TITLE
Updated Carousel.js, Found typo in doc

### DIFF
--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -81,7 +81,7 @@ export default [
             },
             {
                 name: '<code>icon-prev</code>',
-                description: 'pause <code>autoplay</code> if the mouse enters the slide.',
+                description: 'Icon to use for previous arrow',
                 type: 'String',
                 values: '—',
                 default: '<code>chevron-left</code>'


### PR DESCRIPTION
I guess some copy paste was badly handled and thus description for previous icon on carousel was component was wrong

# Fixes
- Fixed typo in carousel API documentation on previous icon
